### PR TITLE
Bugfix: Avoid returning 403 when a user exists based on the oauth-email .

### DIFF
--- a/src/Http/Controllers/SocialiteLoginController.php
+++ b/src/Http/Controllers/SocialiteLoginController.php
@@ -76,6 +76,7 @@ class SocialiteLoginController extends Controller
 
         if ($user) {
             $this->guard()->login($user);
+
             return redirect()->intended();
         }
 

--- a/src/Http/Controllers/SocialiteLoginController.php
+++ b/src/Http/Controllers/SocialiteLoginController.php
@@ -73,8 +73,10 @@ class SocialiteLoginController extends Controller
         }
 
         $user = User::whereEmail($oauthUser->getEmail())->first();
+
         if ($user) {
-            abort(403);
+            $this->guard()->login($user);
+            return redirect()->intended();
         }
 
         DB::beginTransaction();


### PR DESCRIPTION
**Bugfix: Avoid returning 403 when a user exists based on the oauth-email .**

If the user exists should be logged in, and avoid returning a 403 HTTP error.