### PR TITLE
Feature: Allows registration without the password nullable condition.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ However, if you need to keep the user password column not nullable, you can set 
 ```php
 return [
     ...
-    'keep_null_password' => true,
+    'keep_null_password' => false,
     ...
 ];
 ```

--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ return [
     // Allow registration through socials
     'registration' => false,
 
+    // If you set this config to true, the `users.password` column must be nullable
+    // or an error will be thrown when the user is created.
+    // If you set this config to false, the user will be registered using a strong
+    // random password.
+    'keep_null_password' => true,
+
     // Specify the providers that should be visible on the login.
     // These should match the socialite providers you have setup in your services.php config.
     'providers' => [
@@ -73,11 +79,21 @@ composer require owenvoke/blade-fontawesome
 
 ### Registration flow
 
-This package supports account creation for users. However, to support this flow it is important that the `password`
-attribute on your `User` model is nullable. For example, by adding the following to your users table migration.
+This package supports account creation for users. The default registration flow requires the `password`
+attribute on your `User` model must be nullable. For example, by adding the following to your users table migration or creating a new one:
 
 ```php
 $table->string('password')->nullable();
+```
+
+However, if you need to keep the user password column not nullable, you can set in the config file (filament-socialite.php) the option `keep_null_password` to false and the registration flow will create the user with a strong-random password.
+
+```php
+return [
+    ...
+    'keep_null_password' => true,
+    ...
+];
 ```
 
 ### Domain Allowlist

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ attribute on your `User` model must be nullable. For example, by adding the foll
 $table->string('password')->nullable();
 ```
 
-However, if you need to keep the user password column not nullable, you can set in the config file (filament-socialite.php) the option `keep_null_password` to false and the registration flow will create the user with a strong-random password.
+However, if you need to keep the user password column not nullable, you can set in the config file (filament-socialite.php) the option `keep_null_password` to `false`, so the registration flow will create the user with a strong-random password.
 
 ```php
 return [

--- a/config/filament-socialite.php
+++ b/config/filament-socialite.php
@@ -9,6 +9,12 @@ return [
     // Allow registration through socials
     'registration' => false,
 
+    // If you set this config to true, the `users.password` column must be nullable
+    // or an error will be thrown when the user is created.
+    // If you set this config to false, the user will be registered using a strong
+    // random password.
+    'keep_null_password' => true,
+
     // Specify the providers that should be visible on the login.
     // These should match the socialite providers you have setup in your services.php config.
     // Uses blade UI icons, for example: https://github.com/owenvoke/blade-fontawesome

--- a/src/Http/Controllers/SocialiteLoginController.php
+++ b/src/Http/Controllers/SocialiteLoginController.php
@@ -12,6 +12,7 @@ use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
 use Laravel\Socialite\Facades\Socialite;
 use Laravel\Socialite\Two\InvalidStateException;
@@ -95,10 +96,12 @@ class SocialiteLoginController extends Controller
                 [
                     'name' => $oauthUser->getName(),
                     'email' => $oauthUser->getEmail(),
-                    'password' => null,
+                    'password' => config('filament-socialite.keep_null_password', true) 
+                        ? null
+                        : Hash::make(Str::random(64))
                 ]
             );
-            SocialiteUser::create([
+            $socialiteUser = SocialiteUser::create([
                 'user_id' => $user->id,
                 'provider' => $provider,
                 'provider_id' => $oauthUser->getId(),


### PR DESCRIPTION
This PR allows the user's registration without the requirement to change the password column to nullable.

However, the PR keeps the actual behavior (the password column must be nullable) and works only if the config option `keep_null_password` is set to false.

The readme file was updated to include documentation about this.

Regards.
