### PR TITLE
Existing User should be linked

### DIFF
--- a/src/Events/Transfered.php
+++ b/src/Events/Transfered.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace DutchCodingCompany\FilamentSocialite\Events;
+
+use DutchCodingCompany\FilamentSocialite\Models\SocialiteUser;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class Transfered
+{
+    use Dispatchable;
+    use SerializesModels;
+
+    /**
+     * Create a new event instance.
+     *
+     * @return void
+     */
+    public function __construct(public SocialiteUser $socialiteUser)
+    {
+    }
+}

--- a/src/Http/Controllers/SocialiteLoginController.php
+++ b/src/Http/Controllers/SocialiteLoginController.php
@@ -6,6 +6,7 @@ use App\Models\User;
 use DutchCodingCompany\FilamentSocialite\Events\DomainFailed;
 use DutchCodingCompany\FilamentSocialite\Events\Login;
 use DutchCodingCompany\FilamentSocialite\Events\Registered;
+use DutchCodingCompany\FilamentSocialite\Events\Transfered;
 use DutchCodingCompany\FilamentSocialite\Events\RegistrationFailed;
 use DutchCodingCompany\FilamentSocialite\Models\SocialiteUser;
 use Illuminate\Http\Request;
@@ -83,10 +84,18 @@ class SocialiteLoginController extends Controller
         $user = User::whereEmail($oauthUser->getEmail())->first();
 
         if ($user) {
-            $this->guard()->login($user);
 
-            return redirect()->intended();
-        }
+            $socialiteUser = SocialiteUser::create([
+               'user_id' => $user->id,
+               'provider' => $provider,
+               'provider_id' => $oauthUser->getId(),
+           ]);
+           Transfered::dispatch($socialiteUser);
+           $this->guard()->login($user);
+           Login::dispatch($socialiteUser);
+
+           return redirect()->intended();
+       }
 
         DB::beginTransaction();
 


### PR DESCRIPTION
When trying to auth, but the user is not already a socialite user, the existing user database is checked, and if a user found, authenticated,

[ ] First - Add the user to socialite users
[ ]  Next trigger event `Transfered` -- this event will allow you to catch the event , store the detail and send them somewhere custom to confirm their current password or do nothing -- IT IS up to the intergrator to remove the link if there is further confirmation required
[ ] next login and trigger the `Login` event