### PR TITLE
Fix #18: Load redirect route from `filament-socialite` config

### DIFF
--- a/config/filament-socialite.php
+++ b/config/filament-socialite.php
@@ -28,4 +28,7 @@ return [
 
     // Specify the default redirect route for successful logins
     'login_redirect_route' => 'filament.pages.dashboard',
+
+    // Specify the route name for the socialite login page
+    'login_page_route' => 'filament.auth.login',
 ];

--- a/src/Http/Controllers/SocialiteLoginController.php
+++ b/src/Http/Controllers/SocialiteLoginController.php
@@ -55,7 +55,7 @@ class SocialiteLoginController extends Controller
     protected function redirectToLogin(string $message): RedirectResponse
     {
         // Redirect back to the login route with an error message attached
-        return redirect()->route(config('filament-socialite.login_page_route'))
+        return redirect()->route(config('filament-socialite.login_page_route', 'filament.auth.login'))
                 ->withErrors([
                     'email' => [
                         __($message),

--- a/src/Http/Controllers/SocialiteLoginController.php
+++ b/src/Http/Controllers/SocialiteLoginController.php
@@ -55,7 +55,7 @@ class SocialiteLoginController extends Controller
     protected function redirectToLogin(string $message): RedirectResponse
     {
         // Redirect back to the login route with an error message attached
-        return redirect()->route(config('filament.auth.login'))
+        return redirect()->route(config('filament-socialite.login_page_route'))
                 ->withErrors([
                     'email' => [
                         __($message),


### PR DESCRIPTION
## About
Fixes https://github.com/DutchCodingCompany/filament-socialite/issues/18, a suspected bug causing an exception to be thrown when attempting to load a route using null as the key. This PR adds a configuration option to your config file, with the default value linking to the default Filament login page. 

### Extra 
Sidenote, this does not attempt to do anything about the possible XY problem I encountered here https://github.com/DutchCodingCompany/filament-socialite/issues/18#issuecomment-1219093135