### PR TITLE
Fix login route on errors

### DIFF
--- a/src/Http/Controllers/SocialiteLoginController.php
+++ b/src/Http/Controllers/SocialiteLoginController.php
@@ -55,7 +55,7 @@ class SocialiteLoginController extends Controller
     protected function redirectToLogin(string $message): RedirectResponse
     {
         // Redirect back to the login route with an error message attached
-        return redirect()->route(config('filament.auth.login'))
+        return redirect()->route('filament.auth.login')
                 ->withErrors([
                     'email' => [
                         __($message),


### PR DESCRIPTION
Config.filament.auth.login is not part of a filament configuration, but `filament.auth.login` is a default route in the `filament.web` route namespace. 