### PR TITLE
full width if only 1 provider, 2 columns if more

### DIFF
--- a/resources/views/components/buttons.blade.php
+++ b/resources/views/components/buttons.blade.php
@@ -6,7 +6,7 @@
         </p>
     </div>
 
-    <div class="grid @if(count($providers)>1) grid-cols-2 @endif gap-4">
+    <div class="grid @if(count($providers) > 1) grid-cols-2 @endif gap-4">
         @foreach($providers as $key => $provider)
             <x-filament::button
                 color="secondary"

--- a/resources/views/components/buttons.blade.php
+++ b/resources/views/components/buttons.blade.php
@@ -6,7 +6,7 @@
         </p>
     </div>
 
-    <div class="grid grid-cols-2 gap-4">
+    <div class="grid @if(count($providers)>1) grid-cols-2 @endif gap-4">
         @foreach($providers as $key => $provider)
             <x-filament::button
                 color="secondary"


### PR DESCRIPTION
When there's only one provider defined it makes sense to show the button full width.