### PR TITLE
Use set scopes instead of scopes when redirecting to provider

### DIFF
--- a/src/Http/Controllers/SocialiteLoginController.php
+++ b/src/Http/Controllers/SocialiteLoginController.php
@@ -29,7 +29,7 @@ class SocialiteLoginController extends Controller
         }
 
         return Socialite::with($provider)
-            ->scopes($this->socialite->getProviderScopes($provider))
+            ->setScopes($this->socialite->getProviderScopes($provider))
             ->redirect();
     }
 


### PR DESCRIPTION
Sometimes SocialiteProviders come with an default annoying default scope - I think it would be better to use setScopes rather than scopes, as the latter merges with these default scopes, rather than allowing the user to be explicit and set them.

In my case I was using the [Orcid SocialiteProvider](https://github.com/SocialiteProviders/Orcid) which included a member only API scope, where I wanted to use just the public API.  

I have submitted a PR for the above provider too, but feel setting scopes in the services.php file explicitly, as this plugin does, must be a better pattern.
