### PR TITLE
Add a configurable remember login option

### DIFF
--- a/config/filament-socialite.php
+++ b/config/filament-socialite.php
@@ -31,4 +31,7 @@ return [
 
     // Specify the route name for the socialite login page
     'login_page_route' => 'filament.auth.login',
+    
+    // Should the user stay logged in?
+    'remember_login' => false,
 ];

--- a/src/Http/Controllers/SocialiteLoginController.php
+++ b/src/Http/Controllers/SocialiteLoginController.php
@@ -89,7 +89,7 @@ class SocialiteLoginController extends Controller
     protected function loginUser(SocialiteUser $socialiteUser)
     {
         // Log the user in
-        $this->socialite->getGuard()->login($socialiteUser->user);
+        $this->socialite->getGuard()->login($socialiteUser->user, config('filament-socialite.remember_login', false));
 
         // Dispatch the login event
         Events\Login::dispatch($socialiteUser);


### PR DESCRIPTION
Something I've found annoying when using Socialite logins is that I don't stay logged in for long. This PR adds a config option that allows users to stay logged in, akin to the standard "remember me" button. I set the default value to false, to preserve the current behaviour.

If this is not something you as the maintainers are interested in I totally understand, but it's something I found useful so I though I should PR it. Thanks for a great package!