### PR TITLE
Improve domain routing

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -13,16 +13,17 @@ foreach (Filament::getPanels() as $panel) {
     // Retrieve slug for route name.
     $slug = $panel->getPlugin('filament-socialite')->getSlug();
 
-    // Build domain options if they exist.
-    $domains = ! empty($panel->getDomains()) ? '('.collect($panel->getDomains())->join('|').')' : null;
+    $domains = $panel->getDomains();
 
-    Route::domain($domains)
-        ->middleware($panel->getMiddleware())
-        ->name("socialite.$slug.")
-        ->group(function () use ($slug) {
-            Route::get("/$slug/oauth/{provider}", [SocialiteLoginController::class, 'redirectToProvider'])
-                ->name('oauth.redirect');
-        })->where(['domain' => $domains]);
+    foreach ((empty($domains) ? [null] : $domains) as $domain) {
+        Route::domain($domain)
+            ->middleware($panel->getMiddleware())
+            ->name("socialite.$slug.")
+            ->group(function () use ($slug) {
+                Route::get("/$slug/oauth/{provider}", [SocialiteLoginController::class, 'redirectToProvider'])
+                    ->name('oauth.redirect');
+            });
+    }
 }
 
 Route::get("/oauth/callback/{provider}", [SocialiteLoginController::class, 'processCallback'])


### PR DESCRIPTION
Apparently, Filament itself uses a suboptimal way to provide functionality for multiple domains (you cant cache them). So i applied the route logic the same way as they did (which is looping the domains and adding the routes, even if multiple domains cause multiple routes with the same name).

Should fix https://github.com/DutchCodingCompany/filament-socialite/issues/60