### PR TITLE
Multi-tenancy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,28 @@ One can set a callback to customize the following actions:
 
 See [FilamentSocialite.php](src/FilamentSocialite.php).
 
+### Multi-tenancy support
+
+When your panel has [multi-tenancy](https://filamentphp.com/docs/3.x/panels/tenancy) enabled, after logging in, the user will be redirected to there [default tenant](https://filamentphp.com/docs/3.x/panels/tenancy#setting-the-default-tenant). If you want to change this behavior, you can add the `setRedirectTenantCallback` method in the boot method of your `AppServiceProvider.php`:
+
+```php
+use DutchCodingCompany\FilamentSocialite\Facades\FilamentSocialite;
+use DutchCodingCompany\FilamentSocialite\Models\SocialiteUser;
+
+FilamentSocialite::setRedirectTenantCallback(function (Panel $panel, SocialiteUser $socialiteUser) {
+    // Overwrite tentant redirect logic here.
+});
+```
+
+Default logic:
+```php
+$tenant = Filament::getUserDefaultTenant($socialiteUser->user);
+
+return redirect()->intended(
+    $panel->getUrl($tenant)
+);
+```
+
 ### Filament Fortify
 
 This component can also be added while using the [Fortify plugin](https://filamentphp.com/plugins/fortify) plugin.

--- a/src/FilamentSocialite.php
+++ b/src/FilamentSocialite.php
@@ -163,6 +163,10 @@ class FilamentSocialite
         return $this->redirectTenantCallback ?? function (Panel $panel, SocialiteUser $socialiteUser) {
             $tenant = Filament::getUserDefaultTenant($socialiteUser->user);
 
+            if (is_null($tenant) && $tenantRegistrationUrl = $panel->getTenantRegistrationUrl()) {
+                return redirect()->intended($tenantRegistrationUrl);
+            }
+
             return redirect()->intended(
                 $panel->getUrl($tenant)
             );

--- a/src/Http/Controllers/SocialiteLoginController.php
+++ b/src/Http/Controllers/SocialiteLoginController.php
@@ -7,7 +7,6 @@ use DutchCodingCompany\FilamentSocialite\Exceptions\ProviderNotConfigured;
 use DutchCodingCompany\FilamentSocialite\FilamentSocialite;
 use DutchCodingCompany\FilamentSocialite\Http\Middleware\PanelFromUrlQuery;
 use DutchCodingCompany\FilamentSocialite\Models\SocialiteUser;
-use Filament\Facades\Filament;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Routing\Controller;

--- a/src/Http/Controllers/SocialiteLoginController.php
+++ b/src/Http/Controllers/SocialiteLoginController.php
@@ -7,6 +7,7 @@ use DutchCodingCompany\FilamentSocialite\Exceptions\ProviderNotConfigured;
 use DutchCodingCompany\FilamentSocialite\FilamentSocialite;
 use DutchCodingCompany\FilamentSocialite\Http\Middleware\PanelFromUrlQuery;
 use DutchCodingCompany\FilamentSocialite\Models\SocialiteUser;
+use Filament\Facades\Filament;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Routing\Controller;
@@ -103,6 +104,11 @@ class SocialiteLoginController extends Controller
 
         // Dispatch the login event
         Events\Login::dispatch($socialiteUser);
+
+        $panel = $this->socialite->getPanel();
+        if ($panel->hasTenancy()) {
+            return app()->call($this->socialite->getRedirectTenantCallback(), ['panel' => $panel, 'socialiteUser' => $socialiteUser]);
+        }
 
         // Redirect as intended
         return redirect()->intended(


### PR DESCRIPTION
Solution for #68.

When a panel has multi-tenancy set up, the user will be redirected to their [default panel](https://filamentphp.com/docs/3.x/panels/tenancy#setting-the-default-tenant). You can change this behaviour by using the `setRedirectTenantCallback` function.