### PR TITLE
Allow existing user to register socialite user

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ You need to register the plugin in the Filament panel provider (the default file
         ])
         // (optional) Enable or disable registration from OAuth.
         ->setRegistrationEnabled(true)
+        // (optional) Enable or disable socialite registration for existing users from OAuth.
+        ->setSocialiteRegistrationEnabled(true)
         // (optional) Change the associated model class.
         ->setUserModelClass(\App\Models\User::class)
 );

--- a/src/Events/SocialiteRegistrationNotEnabled.php
+++ b/src/Events/SocialiteRegistrationNotEnabled.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace DutchCodingCompany\FilamentSocialite\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use Laravel\Socialite\Contracts\User as SocialiteUserContract;
+
+class SocialiteRegistrationNotEnabled
+{
+    use Dispatchable;
+    use SerializesModels;
+
+    /**
+     * Create a new event instance.
+     *
+     * @return void
+     */
+    public function __construct(
+        public string $provider,
+        public SocialiteUserContract $oauthUser,
+    ) {
+    }
+}

--- a/src/FilamentSocialitePlugin.php
+++ b/src/FilamentSocialitePlugin.php
@@ -18,6 +18,8 @@ class FilamentSocialitePlugin implements Plugin
 
     protected bool $rememberLogin = false;
 
+    protected bool $socialiteRegistrationEnabled = false;
+
     protected bool $registrationEnabled = false;
 
     protected array $domainAllowList = [];
@@ -121,6 +123,18 @@ class FilamentSocialitePlugin implements Plugin
     public function getRememberLogin(): bool
     {
         return $this->rememberLogin;
+    }
+
+    public function setSocialiteRegistrationEnabled(bool $value): static
+    {
+        $this->socialiteRegistrationEnabled = $value;
+
+        return $this;
+    }
+
+    public function getSocialiteRegistrationEnabled(): bool
+    {
+        return $this->socialiteRegistrationEnabled;
     }
 
     public function setRegistrationEnabled(bool $value): static

--- a/src/Http/Controllers/SocialiteLoginController.php
+++ b/src/Http/Controllers/SocialiteLoginController.php
@@ -169,7 +169,7 @@ class SocialiteLoginController extends Controller
         $user = app()->call($this->socialite->getUserResolver(), ['provider' => $provider, 'oauthUser' => $oauthUser, 'socialite' => $this->socialite]);
 
         // See if socialite registration is allowed
-        if ($user && ! $this->socialite->getPlugin()->getSocialiteRegistrationEnabled()) {
+        if ($user && ! ($this->socialite->getPlugin()->getSocialiteRegistrationEnabled() || $this->socialite->getPlugin()->getRegistrationEnabled())) {
             Events\SocialiteRegistrationNotEnabled::dispatch($provider, $oauthUser);
 
             return $this->redirectToLogin('filament-socialite::auth.registration-not-enabled');


### PR DESCRIPTION
Allow existing users to register a Socialite user, without there being the possibility of registering new users.

Sometimes, you may want to enable users to link their user account, without being able to create new user accounts.
A variable (`socialiteRegistrationEnabled`) can be used to enable this behaviour. The functionality for `registrationEnabled` stays the same.