### PR TITLE
Add registration enabled callable

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ php artisan vendor:publish --tag="filament-socialite-translations"
 You need to register the plugin in the Filament panel provider (the default filename is `app/Providers/Filament/AdminPanelProvider.php`). The following options are available:
 
 ```php
+use Laravel\Socialite\Contracts\User as SocialiteUserContract;
+use Illuminate\Contracts\Auth\Authenticatable;
+
+// ...
 ->plugin(
     FilamentSocialitePlugin::make()
         // (required) Add providers corresponding with providers in `config/services.php`. 
@@ -56,8 +60,11 @@ You need to register the plugin in the Filament panel provider (the default file
                 'outlined' => false,
             ],
         ])
-        // (optional) Enable or disable registration from OAuth.
+        // (optional) Enable/disable registration of new (socialite-) users.
         ->setRegistrationEnabled(true)
+        // (optional) Enable/disable registration of new (socialite-) users using a callback.
+        // In this example, a login flow can only continue if there exists a user (Authenticatable) already.
+        ->setRegistrationEnabled(fn (string $provider, SocialiteUserContract $oauthUser, ?Authenticatable $user) => (bool) $user)
         // (optional) Change the associated model class.
         ->setUserModelClass(\App\Models\User::class)
         // (optional) Change the associated socialite class (see below).

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11,8 +11,13 @@ parameters:
 			path: src/FilamentSocialitePlugin.php
 
 		-
-			message: "#^Call to an undefined method Mockery\\\\ExpectationInterface\\|Mockery\\\\HigherOrderMessage\\:\\:andReturn\\(\\)\\.$#"
+			message: "#^Parameter \\#1 \\$value of method DutchCodingCompany\\\\FilamentSocialite\\\\Http\\\\Controllers\\\\SocialiteLoginController\\:\\:evaluate\\(\\) expects bool\\|\\(callable\\(\\)\\: bool\\), bool\\|\\(Closure\\(string, Laravel\\\\Socialite\\\\Contracts\\\\User, Illuminate\\\\Contracts\\\\Auth\\\\Authenticatable\\|null\\)\\: bool\\) given\\.$#"
 			count: 1
+			path: src/Http/Controllers/SocialiteLoginController.php
+
+		-
+			message: "#^Call to an undefined method Mockery\\\\ExpectationInterface\\|Mockery\\\\HigherOrderMessage\\:\\:andReturn\\(\\)\\.$#"
+			count: 2
 			path: tests/SocialiteLoginTest.php
 
 		-

--- a/src/Events/RegistrationNotEnabled.php
+++ b/src/Events/RegistrationNotEnabled.php
@@ -2,6 +2,7 @@
 
 namespace DutchCodingCompany\FilamentSocialite\Events;
 
+use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 use Laravel\Socialite\Contracts\User as SocialiteUserContract;
@@ -19,6 +20,7 @@ class RegistrationNotEnabled
     public function __construct(
         public string $provider,
         public SocialiteUserContract $oauthUser,
+        public ?Authenticatable $user,
     ) {
     }
 }

--- a/src/FilamentSocialitePlugin.php
+++ b/src/FilamentSocialitePlugin.php
@@ -3,6 +3,7 @@
 namespace DutchCodingCompany\FilamentSocialite;
 
 use App\Models\User;
+use Closure;
 use DutchCodingCompany\FilamentSocialite\Exceptions\ImplementationException;
 use DutchCodingCompany\FilamentSocialite\Models\Contracts\FilamentSocialiteUser as FilamentSocialiteUserContract;
 use DutchCodingCompany\FilamentSocialite\Models\SocialiteUser;
@@ -24,7 +25,10 @@ class FilamentSocialitePlugin implements Plugin
 
     protected bool $rememberLogin = false;
 
-    protected bool $registrationEnabled = false;
+    /**
+     * @var \Closure(string $provider, \Laravel\Socialite\Contracts\User $oauthUser, ?\Illuminate\Contracts\Auth\Authenticatable $user): bool|bool
+     */
+    protected Closure | bool $registrationEnabled = false;
 
     /**
      * @var array<string>
@@ -146,14 +150,21 @@ class FilamentSocialitePlugin implements Plugin
         return $this->rememberLogin;
     }
 
-    public function setRegistrationEnabled(bool $value): static
+    /**
+     * @param \Closure(string $provider, \Laravel\Socialite\Contracts\User $oauthUser, ?\Illuminate\Contracts\Auth\Authenticatable $user): bool|bool $value
+     * @return $this
+     */
+    public function setRegistrationEnabled(Closure | bool $value): static
     {
         $this->registrationEnabled = $value;
 
         return $this;
     }
 
-    public function getRegistrationEnabled(): bool
+    /**
+     * @return \Closure(string $provider, \Laravel\Socialite\Contracts\User $oauthUser, ?\Illuminate\Contracts\Auth\Authenticatable $user): bool|bool
+     */
+    public function getRegistrationEnabled(): Closure | bool
     {
         return $this->registrationEnabled;
     }

--- a/src/FilamentSocialitePlugin.php
+++ b/src/FilamentSocialitePlugin.php
@@ -26,7 +26,7 @@ class FilamentSocialitePlugin implements Plugin
     protected bool $rememberLogin = false;
 
     /**
-     * @var \Closure(string $provider, \Laravel\Socialite\Contracts\User $oauthUser, ?\Illuminate\Contracts\Auth\Authenticatable $user): bool|bool
+     * @var \Closure(string, \Laravel\Socialite\Contracts\User, ?\Illuminate\Contracts\Auth\Authenticatable): bool|bool
      */
     protected Closure | bool $registrationEnabled = false;
 

--- a/src/Http/Controllers/SocialiteLoginController.php
+++ b/src/Http/Controllers/SocialiteLoginController.php
@@ -7,6 +7,7 @@ use DutchCodingCompany\FilamentSocialite\Exceptions\ProviderNotConfigured;
 use DutchCodingCompany\FilamentSocialite\FilamentSocialite;
 use DutchCodingCompany\FilamentSocialite\Http\Middleware\PanelFromUrlQuery;
 use DutchCodingCompany\FilamentSocialite\Models\Contracts\FilamentSocialiteUser as FilamentSocialiteUserContract;
+use Filament\Support\Concerns\EvaluatesClosures;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Routing\Controller;
@@ -18,6 +19,8 @@ use Laravel\Socialite\Two\InvalidStateException;
 
 class SocialiteLoginController extends Controller
 {
+    use EvaluatesClosures;
+
     public function __construct(
         protected FilamentSocialite $socialite,
     ) {
@@ -161,15 +164,15 @@ class SocialiteLoginController extends Controller
             return $this->loginUser($socialiteUser);
         }
 
+        // See if a user already exists, but not for this socialite provider
+        $user = app()->call($this->socialite->getUserResolver(), ['provider' => $provider, 'oauthUser' => $oauthUser, 'socialite' => $this->socialite]);
+
         // See if registration is allowed
-        if (! $this->socialite->getPlugin()->getRegistrationEnabled()) {
-            Events\RegistrationNotEnabled::dispatch($provider, $oauthUser);
+        if (! $this->evaluate($this->socialite->getPlugin()->getRegistrationEnabled(), ['provider' => $provider, 'oauthUser' => $oauthUser, 'user' => $user])) {
+            Events\RegistrationNotEnabled::dispatch($provider, $oauthUser, $user);
 
             return $this->redirectToLogin('filament-socialite::auth.registration-not-enabled');
         }
-
-        // See if a user already exists, but not for this socialite provider
-        $user = app()->call($this->socialite->getUserResolver(), ['provider' => $provider, 'oauthUser' => $oauthUser, 'socialite' => $this->socialite]);
 
         // Handle registration
         return $user

--- a/tests/SocialiteLoginTest.php
+++ b/tests/SocialiteLoginTest.php
@@ -2,12 +2,20 @@
 
 namespace DutchCodingCompany\FilamentSocialite\Tests;
 
+use DutchCodingCompany\FilamentSocialite\Events\RegistrationNotEnabled;
+use DutchCodingCompany\FilamentSocialite\Facades\FilamentSocialite;
 use DutchCodingCompany\FilamentSocialite\Tests\Fixtures\TestSocialiteUser;
+use DutchCodingCompany\FilamentSocialite\Tests\Fixtures\TestUser;
+use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Event;
 use Laravel\Socialite\Contracts\Provider;
+use Laravel\Socialite\Contracts\User as SocialiteUserContract;
 use Laravel\Socialite\Facades\Socialite;
 use Mockery;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class SocialiteLoginTest extends TestCase
 {
@@ -54,5 +62,61 @@ class SocialiteLoginTest extends TestCase
             'name' => 'test-socialite-user-name',
             'email' => 'test@example.com',
         ]);
+    }
+
+    #[DataProvider('testProvider')]
+    public function testRegistrationBlock(bool $createUser, \Closure | bool $registrationEnabled): void
+    {
+        Event::fake();
+
+        if ($createUser) {
+            DB::table('users')->insert([
+                'name' => 'test-user',
+                'email' => 'test@example.com',
+            ]);
+        }
+
+        FilamentSocialite::getPlugin()->setRegistrationEnabled($registrationEnabled);
+
+        $this
+            ->getJson("/$this->panelName/oauth/github")
+            ->assertStatus(302);
+
+        Socialite::shouldReceive('driver')
+            ->with('github')
+            ->andReturn(
+                Mockery::mock(Provider::class)
+                    ->shouldReceive('user')
+                    ->andReturn(new TestSocialiteUser())
+                    ->getMock()
+            );
+
+        $state = session()->get('state');
+
+        // Fake oauth response.
+        $this
+            ->getJson("/oauth/callback/github?state=$state")
+            ->assertStatus(302);
+
+        if (! $createUser) {
+            // If there is no user, the event should have been dispatched since the plugin option disabled registration.
+            Event::assertDispatched(RegistrationNotEnabled::class);
+        }
+    }
+
+    /**
+     * @return array<string, array<mixed>>
+     */
+    public static function testProvider(): array
+    {
+        $callback = function (string $provider, SocialiteUserContract $oauthUser, ?Authenticatable $user) {
+            return (bool) $user;
+        };
+
+        return [
+            'Authenticatable exists for socialite user' => [true, $callback],
+            'Authenticatable does not exist for socialite user' => [false, $callback],
+            'Registration is always blocked' => [true, false],
+        ];
     }
 }


### PR DESCRIPTION
This PR adds the possibility for `setRegistrationEnabled()` to accept a closure, so developers can use their own logic to either allow or disallow registration.