### PR TITLE
Add $provider as required by the callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ use DutchCodingCompany\FilamentSocialite\FilamentSocialite;
 use Laravel\Socialite\Contracts\User as SocialiteUserContract;
 
 // Default
-FilamentSocialiteFacade::setCreateUserCallback(fn (SocialiteUserContract $oauthUser, FilamentSocialite $socialite) => $socialite->getUserModelClass()::create([
+FilamentSocialiteFacade::setCreateUserCallback(fn (string $provider, SocialiteUserContract $oauthUser, FilamentSocialite $socialite) => $socialite->getUserModelClass()::create([
     'name' => $oauthUser->getName(),
     'email' => $oauthUser->getEmail(),
 ]));


### PR DESCRIPTION
In #80, the expected closure in `setCreateUserCallback()` was changed from:

`@param \Closure(\Laravel\Socialite\Contracts\User $oauthUser, self $socialite): \Illuminate\Contracts\Auth\Authenticatable $callback`

to:
`@param \Closure(string $provider, \Laravel\Socialite\Contracts\User $oauthUser, self $socialite): \Illuminate\Contracts\Auth\Authenticatable $callback`

See https://github.com/DutchCodingCompany/filament-socialite/pull/80/files#diff-67b15d15cdb909bec4aa64726a764f56356dafdff7ded1b3c6d5cfbfbc10a15cR143

meaning that is expects a `string $provider`. It can work without, however, PHPStan is nagging about it, due to it not being provided in the example.

Error:
```
Parameter #1 $callback of static method DutchCodingCompany\FilamentSocialite\FilamentSocialite::setCreateUserCallback()
         expects (Closure(string, Laravel\Socialite\Contracts\User, DutchCodingCompany\FilamentSocialite\FilamentSocialite):
         Illuminate\Contracts\Auth\Authenticatable)|null, Closure(Laravel\Socialite\Contracts\User,
         DutchCodingCompany\FilamentSocialite\FilamentSocialite): mixed given.
```

This PR updated the example.