### PR TITLE
Never use SPA mode for oauth links + spacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,11 @@ Add OAuth2 login through Laravel Socialite to Filament. OAuth1 (eg. Twitter) is 
 
 ## Installation
 
-| Filament version | Package version |
-|------------------|-----------------|
-| 3.x              | 1.x.x           |
-| 2.x              | 0.x.x           |
+| Filament version                                                                                                                                              | Package version |
+|---------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------|
+| [^3.2.44](https://github.com/filamentphp/filament/releases/tag/v3.2.44) (if using [SPA mode](https://filamentphp.com/docs/3.x/panels/configuration#spa-mode)) | 1.x.x |
+| 3.x                                                                                                                                                           | 1.x.x           |
+| 2.x                                                                                                                                                           | 0.x.x           |
 
 Install the package via composer:
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Add OAuth2 login through Laravel Socialite to Filament. OAuth1 (eg. Twitter) is 
 
 | Filament version                                                                                                                                              | Package version |
 |---------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------|
-| [^3.2.44](https://github.com/filamentphp/filament/releases/tag/v3.2.44) (if using [SPA mode](https://filamentphp.com/docs/3.x/panels/configuration#spa-mode)) | 1.3.1           |
+| [^3.2.44](https://github.com/filamentphp/filament/releases/tag/v3.2.44) (if using [SPA mode](https://filamentphp.com/docs/3.x/panels/configuration#spa-mode)) | ^1.3.1          |
 | 3.x                                                                                                                                                           | 1.x.x           |
 | 2.x                                                                                                                                                           | 0.x.x           |
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Add OAuth2 login through Laravel Socialite to Filament. OAuth1 (eg. Twitter) is 
 
 | Filament version                                                                                                                                              | Package version |
 |---------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------|
-| [^3.2.44](https://github.com/filamentphp/filament/releases/tag/v3.2.44) (if using [SPA mode](https://filamentphp.com/docs/3.x/panels/configuration#spa-mode)) | 1.x.x |
+| [^3.2.44](https://github.com/filamentphp/filament/releases/tag/v3.2.44) (if using [SPA mode](https://filamentphp.com/docs/3.x/panels/configuration#spa-mode)) | 1.3.1           |
 | 3.x                                                                                                                                                           | 1.x.x           |
 | 2.x                                                                                                                                                           | 0.x.x           |
 

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "filament/filament": "^3.2.44",
+        "filament/filament": "^3.0.9",
         "illuminate/contracts": "^10.0",
         "laravel/socialite": "^5.5",
         "spatie/laravel-package-tools": "^1.9.2"

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "filament/filament": "^3.0.9",
+        "filament/filament": "^3.2.44",
         "illuminate/contracts": "^10.0",
         "laravel/socialite": "^5.5",
         "spatie/laravel-package-tools": "^1.9.2"

--- a/resources/views/components/buttons.blade.php
+++ b/resources/views/components/buttons.blade.php
@@ -1,4 +1,4 @@
-<div>
+<div class="flex flex-col gap-y-6">
     @if ($messageBag->isNotEmpty())
         @foreach($messageBag->all() as $value)
             <p class="fi-fo-field-wrp-error-message text-danger-600 dark:text-danger-400">{{ __($value) }}</p>
@@ -23,6 +23,7 @@
                     :icon="$provider['icon'] ?? null"
                     tag="a"
                     :href="route($socialiteRoute, $key)"
+                    :spa-mode="false"
                 >
                     {{ $provider['label'] }}
                 </x-filament::button>


### PR DESCRIPTION
This PR fixes the oauth redirect when in Filament SPA mode, by setting a specific property on the button added in [^3.2.44](https://github.com/filamentphp/filament/releases/tag/v3.2.44). This fixes a CORS issue since the oauth request is now no longer sent via XHR.

It also changes the "or login via" spacing a bit on the login page:

old:
![image](https://github.com/DutchCodingCompany/filament-socialite/assets/10498595/1ee44b71-7df9-4139-ac8e-d441e8e15456)

new:
![image](https://github.com/DutchCodingCompany/filament-socialite/assets/10498595/1366d79f-0e28-47af-bbd5-d23baad3dd05)
