### PR TITLE
Authorization Callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `filament-socialite` will be documented in this file.
 
+## [2.2.0 - 2024-06-21](https://github.com/DutchCodingCompany/filament-socialite/compare/2.0.0...2.1.0)
+
+* Add Authorization Callback by @petecoop in https://github.com/DutchCodingCompany/filament-socialite/pull/100
+
 ## [2.0.0 - 2024-06-04](https://github.com/DutchCodingCompany/filament-socialite/compare/1.5.0...2.0.0)
 * **Please check the revised [README.md](https://github.com/DutchCodingCompany/filament-socialite/blob/main/README.md) and [UPGRADE.md](https://github.com/DutchCodingCompany/filament-socialite/blob/main/UPGRADE.md)! Many functions have been renamed.**
 * Refactor package for better consistency with Filament code standards https://github.com/DutchCodingCompany/filament-socialite/pull/90

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ use Laravel\Socialite\Contracts\User as SocialiteUserContract;
         // ...
         ->authorizeUserUsing(function (FilamentSocialitePlugin $plugin, SocialiteUserContract $oauthUser) {
             // Logic to authorize the user.
-            return static::checkDomainAllowList($plugin, $oauthUser);
+            return FilamentSocialitePlugin::checkDomainAllowList($plugin, $oauthUser);
         })
         // ...
 );

--- a/README.md
+++ b/README.md
@@ -175,6 +175,25 @@ class SocialiteUser implements FilamentSocialiteUserContract
 }
 ```
 
+### Check if the user is authorized to use the application
+
+You can use the `authorizeUserUsing` method to check if the user is authorized to use the application. **Note:** by [default](/src/Traits/Callbacks.php#L145) this method check if the user's email domain is in the domain allow list.
+
+```php
+use DutchCodingCompany\FilamentSocialite\FilamentSocialitePlugin;
+use Laravel\Socialite\Contracts\User as SocialiteUserContract;
+
+->plugin(
+    FilamentSocialitePlugin::make()
+        // ...
+        ->authorizeUserUsing(function (FilamentSocialitePlugin $plugin, SocialiteUserContract $oauthUser) {
+            // Logic to authorize the user.
+            return static::checkDomainAllowList($plugin, $oauthUser);
+        })
+        // ...
+);
+```
+
 ### Change login redirect
 
 When your panel has [multi-tenancy](https://filamentphp.com/docs/3.x/panels/tenancy) enabled, after logging in, the user will be redirected to their [default tenant](https://filamentphp.com/docs/3.x/panels/tenancy#setting-the-default-tenant).

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -17,6 +17,11 @@ parameters:
 
 		-
 			message: "#^Call to an undefined method Mockery\\\\ExpectationInterface\\|Mockery\\\\HigherOrderMessage\\:\\:andReturn\\(\\)\\.$#"
+			count: 1
+			path: tests/SocialiteLoginAuthorizationTest.php
+
+		-
+			message: "#^Call to an undefined method Mockery\\\\ExpectationInterface\\|Mockery\\\\HigherOrderMessage\\:\\:andReturn\\(\\)\\.$#"
 			count: 2
 			path: tests/SocialiteLoginTest.php
 

--- a/resources/lang/en/auth.php
+++ b/resources/lang/en/auth.php
@@ -5,7 +5,7 @@ return [
 
     'login-failed' => 'Login failed, please try again.',
 
-    'user-not-authorized' => 'You are not authorized to use this application.',
+    'user-not-allowed' => 'Your email is not part of a domain that is allowed.',
 
     'registration-not-enabled' => 'Registration of a new user is not allowed.',
 ];

--- a/resources/lang/en/auth.php
+++ b/resources/lang/en/auth.php
@@ -8,5 +8,7 @@ return [
 
     'user-not-allowed' => 'Your email is not part of a domain that is allowed.',
 
+    'user-not-authorized' => 'You are not authorized to use this application.',
+
     'registration-not-enabled' => 'Registration of a new user is not allowed.',
 ];

--- a/resources/lang/en/auth.php
+++ b/resources/lang/en/auth.php
@@ -1,12 +1,9 @@
 <?php
 
 return [
-
     'login-via' => 'Or log in via',
 
     'login-failed' => 'Login failed, please try again.',
-
-    'user-not-allowed' => 'Your email is not part of a domain that is allowed.',
 
     'user-not-authorized' => 'You are not authorized to use this application.',
 

--- a/src/Http/Controllers/SocialiteLoginController.php
+++ b/src/Http/Controllers/SocialiteLoginController.php
@@ -3,7 +3,6 @@
 namespace DutchCodingCompany\FilamentSocialite\Http\Controllers;
 
 use DutchCodingCompany\FilamentSocialite\Events;
-use DutchCodingCompany\FilamentSocialite\Exceptions\ImplementationException;
 use DutchCodingCompany\FilamentSocialite\Exceptions\ProviderNotConfigured;
 use DutchCodingCompany\FilamentSocialite\FilamentSocialitePlugin;
 use DutchCodingCompany\FilamentSocialite\Http\Middleware\PanelFromUrlQuery;
@@ -13,7 +12,6 @@ use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Str;
 use Laravel\Socialite\Contracts\User as SocialiteUserContract;
 use Laravel\Socialite\Facades\Socialite;
 use Laravel\Socialite\Two\InvalidStateException;

--- a/src/Http/Controllers/SocialiteLoginController.php
+++ b/src/Http/Controllers/SocialiteLoginController.php
@@ -142,7 +142,7 @@ class SocialiteLoginController extends Controller
         if (! $this->authorizeUser($oauthUser)) {
             Events\UserNotAllowed::dispatch($oauthUser);
 
-            return $this->redirectToLogin('filament-socialite::auth.user-not-authorized');
+            return $this->redirectToLogin('filament-socialite::auth.user-not-allowed');
         }
 
         // Try to find a socialite user

--- a/src/Http/Controllers/SocialiteLoginController.php
+++ b/src/Http/Controllers/SocialiteLoginController.php
@@ -99,6 +99,11 @@ class SocialiteLoginController extends Controller
         return in_array($emailDomain, $domains);
     }
 
+    protected function authorizeUser(SocialiteUserContract $user): bool
+    {
+        return app()->call($this->plugin()->getAuthorizeUserUsing(), ['oauthUser' => $user]);
+    }
+
     protected function loginUser(string $provider, FilamentSocialiteUserContract $socialiteUser, SocialiteUserContract $oauthUser): RedirectResponse
     {
         // Log the user in
@@ -157,6 +162,13 @@ class SocialiteLoginController extends Controller
             Events\UserNotAllowed::dispatch($oauthUser);
 
             return $this->redirectToLogin('filament-socialite::auth.user-not-allowed');
+        }
+
+        $authorized = $this->authorizeUser($oauthUser);
+        if (! $authorized) {
+            Events\UserNotAllowed::dispatch($oauthUser);
+
+            return $this->redirectToLogin('filament-socialite::auth.user-not-authorized');
         }
 
         // Try to find a socialite user

--- a/src/Http/Controllers/SocialiteLoginController.php
+++ b/src/Http/Controllers/SocialiteLoginController.php
@@ -164,8 +164,7 @@ class SocialiteLoginController extends Controller
             return $this->redirectToLogin('filament-socialite::auth.user-not-allowed');
         }
 
-        $authorized = $this->authorizeUser($oauthUser);
-        if (! $authorized) {
+        if (! $this->authorizeUser($oauthUser)) {
             Events\UserNotAllowed::dispatch($oauthUser);
 
             return $this->redirectToLogin('filament-socialite::auth.user-not-authorized');

--- a/src/Traits/Callbacks.php
+++ b/src/Traits/Callbacks.php
@@ -119,7 +119,7 @@ trait Callbacks
                 'email',
                 $oauthUser->getEmail()
             )->first();
-            };
+        };
     }
 
     /**

--- a/src/Traits/Callbacks.php
+++ b/src/Traits/Callbacks.php
@@ -26,6 +26,11 @@ trait Callbacks
     protected ?Closure $resolveUserUsing = null;
 
     /**
+     * @phpstan-var ?\Closure(\Laravel\Socialite\Contracts\User $oauthUser): bool
+     */
+    protected ?Closure $authorizeUserUsing = null;
+
+    /**
      * @param ?\Closure(string $provider, \Laravel\Socialite\Contracts\User $oauthUser, \DutchCodingCompany\FilamentSocialite\FilamentSocialitePlugin $plugin): \Illuminate\Contracts\Auth\Authenticatable $callback
      */
     public function createUserUsing(Closure $callback = null): static
@@ -114,6 +119,24 @@ trait Callbacks
                 'email',
                 $oauthUser->getEmail()
             )->first();
-        };
+            };
+    }
+
+    /**
+     * @param \Closure(\Laravel\Socialite\Contracts\User $oauthUser): bool $callback
+     */
+    public function authorizeUserUsing(Closure $callback = null): static
+    {
+        $this->authorizeUserUsing = $callback;
+
+        return $this;
+    }
+
+    /**
+     * @return \Closure(\Laravel\Socialite\Contracts\User $oauthUser): bool $callback
+     */
+    public function getAuthorizeUserUsing(): Closure
+    {
+        return $this->authorizeUserUsing ?? fn() => true;
     }
 }

--- a/tests/Fixtures/TestSocialiteUser.php
+++ b/tests/Fixtures/TestSocialiteUser.php
@@ -6,6 +6,8 @@ use Laravel\Socialite\Contracts\User;
 
 class TestSocialiteUser implements User
 {
+    public string $email = 'test@example.com';
+
     public function getId()
     {
         return 'test-socialite-user-id';
@@ -23,7 +25,7 @@ class TestSocialiteUser implements User
 
     public function getEmail()
     {
-        return 'test@example.com';
+        return $this->email;
     }
 
     public function getAvatar()

--- a/tests/SocialiteLoginAuthorizationTest.php
+++ b/tests/SocialiteLoginAuthorizationTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace DutchCodingCompany\FilamentSocialite\Tests;
+
+use DutchCodingCompany\FilamentSocialite\Events\UserNotAllowed;
+use DutchCodingCompany\FilamentSocialite\Tests\Fixtures\TestSocialiteUser;
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\Event;
+use Laravel\Socialite\Contracts\User as SocialiteUserContract;
+use DutchCodingCompany\FilamentSocialite\FilamentSocialitePlugin;
+use DutchCodingCompany\FilamentSocialite\Provider;
+use Filament\Facades\Filament;
+use Filament\Pages\Dashboard;
+use Filament\Panel;
+use Mockery;
+use Laravel\Socialite\Facades\Socialite;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+class SocialiteLoginAuthorizationTest extends TestCase
+{
+    protected function registerTestPanel(): void
+    {
+        Filament::registerPanel(
+            fn (): Panel => Panel::make()
+                ->default()
+                ->id($this->panelName)
+                ->path($this->panelName)
+                ->tenant(...$this->tenantArguments)
+                ->login()
+                ->pages([
+                    Dashboard::class,
+                ])
+                ->plugins([
+                    FilamentSocialitePlugin::make()
+                        ->providers([
+                            Provider::make('github')
+                                ->label('GitHub')
+                                ->icon('fab-github')
+                                ->color('danger')
+                                ->outlined(false),
+                            Provider::make('gitlab')
+                                ->label('GitLab')
+                                ->icon('fab-gitlab')
+                                ->color('danger')
+                                ->outlined()
+                                ->scopes([])
+                                ->with([]),
+                        ])
+                        ->registration(true)
+                        ->userModelClass($this->userModelClass)
+                        ->authorizeUserUsing(function (FilamentSocialitePlugin $plugin, SocialiteUserContract $oauthUser) {
+                            return $oauthUser->getEmail() === 'test@example.com';
+                        })
+                ]),
+        );
+    }
+
+    #[DataProvider('loginDataProvider')]
+    public function testAuthorizationLogin(string $email, bool $dispatchesUserNotAllowedEvent): void
+    {
+        Event::fake();
+
+        $response = $this
+            ->getJson("/$this->panelName/oauth/github")
+            ->assertStatus(302);
+
+        $state = session()->get('state');
+
+        $location = $response->headers->get('location') ?? throw new LogicException('Location header not set.');
+
+        parse_str($location, $urlQuery);
+
+        // Test if the correct state is sent to the endpoint in the "Location" header.
+        $this->assertEquals($state, $urlQuery['state']);
+
+        // Assert decrypting of the state gives the correct panel name.
+        $this->assertEquals($this->panelName, Crypt::decrypt($state));
+
+        $user = new TestSocialiteUser();
+        $user->email = $email;
+
+        Socialite::shouldReceive('driver')
+            ->with('github')
+            ->andReturn(
+                Mockery::mock(\Laravel\Socialite\Contracts\Provider::class)
+                    ->shouldReceive('user')
+                    ->andReturn($user)
+                    ->getMock()
+            );
+
+        // Fake oauth response.
+        $this->getJson("/oauth/callback/github?state=$state")
+            ->assertStatus(302);
+
+        $dispatchesUserNotAllowedEvent
+            ? Event::assertDispatched(UserNotAllowed::class)
+            : Event::assertNotDispatched(UserNotAllowed::class);
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: bool}>
+     */
+    public static function loginDataProvider(): array
+    {
+        return [
+            'User is authorized to use the application so UserNotAllowedEvent should not be dispatched' => [
+                'test@example.com',
+                false,
+            ],
+            'User is not authorized to use the application so UserNotAllowedEvent should be dispatched' => [
+                'test@example1.com',
+                true,
+            ],
+        ];
+    }
+}

--- a/tests/SocialiteLoginTest.php
+++ b/tests/SocialiteLoginTest.php
@@ -60,6 +60,16 @@ class SocialiteLoginTest extends TestCase
 
         if ($dispatchesUserNotAllowedEvent) {
             Event::assertDispatched(UserNotAllowed::class);
+
+            $this->assertDatabaseMissing('socialite_users', [
+                'provider' => 'github',
+                'provider_id' => 'test-socialite-user-id',
+            ]);
+
+            $this->assertDatabaseMissing('users', [
+                'name' => 'test-socialite-user-name',
+                'email' => $user->email,
+            ]);
         } else {
             $this->assertDatabaseHas('socialite_users', [
                 'provider' => 'github',

--- a/tests/SocialiteLoginTest.php
+++ b/tests/SocialiteLoginTest.php
@@ -78,7 +78,7 @@ class SocialiteLoginTest extends TestCase
 
             $this->assertDatabaseHas('users', [
                 'name' => 'test-socialite-user-name',
-                'email' => 'test@example.com',
+                'email' => $user->email,
             ]);
         }
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -88,7 +88,8 @@ class TestCase extends Orchestra
                                 ->with([]),
                         ])
                         ->registration(true)
-                        ->userModelClass($this->userModelClass),
+                        ->userModelClass($this->userModelClass)
+                        ->domainAllowList(['example.com']),
                 ]),
         );
     }


### PR DESCRIPTION
This is something I needed for an integration I'm working on, where only users with an admin user level should be able to login to the system but this could be customised to reject a user for any reason.

Usage:
```php
FilamentSocialitePlugin::make()
    // ...
    ->authorizeUserUsing(function (User $oauthUser) {
        // Logic to authorize a user e.g.
        return $oauthUser->getRaw()['user_level'] === 'admin';
    });
```
