### PR TITLE
feat: Add Spanish localization for authentication messages

### DIFF
--- a/resources/lang/es/auth.php
+++ b/resources/lang/es/auth.php
@@ -1,0 +1,11 @@
+<?php
+
+return [
+    'login-via' => 'O inicie sesión a través de',
+
+    'login-failed' => 'El inicio de sesión falló, por favor inténtelo de nuevo.',
+
+    'user-not-allowed' => 'Su correo electrónico no está autorizado para ingresar.',
+
+    'registration-not-enabled' => 'No está permitido el registro de un nuevo usuario.',
+];


### PR DESCRIPTION
This pull request includes changes to the Spanish language file for authentication messages. The most important changes are the addition of new translations for various authentication-related messages.

New translations added:

* [`resources/lang/es/auth.php`](diffhunk://#diff-7ce1008825bc3498e74acc96b7650384f4867399a22c64ee5bca69bd7ab53de6R1-R11): Added translation for "O inicie sesión a través de".
* [`resources/lang/es/auth.php`](diffhunk://#diff-7ce1008825bc3498e74acc96b7650384f4867399a22c64ee5bca69bd7ab53de6R1-R11): Added translation for "El inicio de sesión falló, por favor inténtelo de nuevo.".
* [`resources/lang/es/auth.php`](diffhunk://#diff-7ce1008825bc3498e74acc96b7650384f4867399a22c64ee5bca69bd7ab53de6R1-R11): Added translation for "Su correo electrónico no está autorizado para ingresar.".
* [`resources/lang/es/auth.php`](diffhunk://#diff-7ce1008825bc3498e74acc96b7650384f4867399a22c64ee5bca69bd7ab53de6R1-R11): Added translation for "No está permitido el registro de un nuevo usuario.".