### PR TITLE
fix: update state retrieval method in PanelFromUrlQuery middleware

### DIFF
--- a/src/Http/Middleware/PanelFromUrlQuery.php
+++ b/src/Http/Middleware/PanelFromUrlQuery.php
@@ -33,11 +33,11 @@ class PanelFromUrlQuery
     public static function decrypt(Request $request): string
     {
         try {
-            if (! is_string($request->get('state'))) {
+            if (! is_string($request->query->get('state'))) {
                 throw new DecryptException('State is not a string.');
             }
 
-            return Crypt::decrypt($request->get('state'));
+            return Crypt::decrypt($request->query->get('state'));
         } catch (DecryptException $e) {
             throw InvalidCallbackPayload::make($e);
         }


### PR DESCRIPTION
Symfony has deprecated the direct `get()` method.
https://symfony.com/blog/new-in-symfony-7-4-request-class-improvements

This should fix the following warning.

```
Since symfony/http-foundation 7.4: Request::get() is deprecated,
use properties ->attributes, query or request directly instead. in
/var/www/vendor/symfony/deprecation-contracts/function.php on line 25
```